### PR TITLE
Fixed TP command parser

### DIFF
--- a/Assets/matchematicsScript.cs
+++ b/Assets/matchematicsScript.cs
@@ -165,7 +165,8 @@ public class matchematicsScript : MonoBehaviour {
 		}
 		bool submit = command.Contains("submit");
 		bool type = submit || command.Contains("type");
-		match = Regex.Match(command, "(?:[^0-9])*([0-9])(?:[^0-9])*([0-9])(?:[^0-9])*([0-9])(?:[^0-9])*");
+		//Check for exactly 3 digits in the command
+		match = Regex.Match(command, "^(?:[^0-9])*([0-9])(?:[^0-9])*([0-9])(?:[^0-9])*([0-9])(?:[^0-9])*$");
 		if (match.Success) {
 			for (int i = 0; i < 3; i++) {
 				nums[i] = int.Parse(match.Groups[i+1].Value);
@@ -179,7 +180,8 @@ public class matchematicsScript : MonoBehaviour {
 				}
 			}
 		}
-		if (submit) output.Add(this.confirmButton);
+		//Press submit only if there is 3 or 0 digits
+		if (submit && (match.Success || !Regex.Match(command, "[0-9]").Success)) output.Add(this.confirmButton);
 		return output;
 	}
 	

--- a/Assets/matchematicsScript.cs
+++ b/Assets/matchematicsScript.cs
@@ -156,34 +156,30 @@ public class matchematicsScript : MonoBehaviour {
 	public string TwitchHelpMessage = "To write digits into the module. Use \"type/submit [3 digits]\" (submit presses the CONFIRM button). use \"reset\" to press the reset button.";
 	public List<KMSelectable> ProcessTwitchCommand(string command) {
 		var output = new List<KMSelectable>();
-		bool confirm = false;
-		bool type = false;
 		var nums = new int[3];
 		command = command.ToLowerInvariant();
 		var match = Regex.Match(command, "reset.*");
-		if (match.Success) {
+		if (command.Contains("reset")) {
 			output.Add(this.resetButton);
 			return output;
 		}
-		match = Regex.Match(command, "(?:type|submit)(?:[^0-9])*([0-9])(?:[^0-9])*([0-9])(?:[^0-9])*([0-9])(?:[^0-9])*");
+		bool submit = command.Contains("submit");
+		bool type = submit || command.Contains("type");
+		match = Regex.Match(command, "(?:[^0-9])*([0-9])(?:[^0-9])*([0-9])(?:[^0-9])*([0-9])(?:[^0-9])*");
 		if (match.Success) {
-			type = true;
 			for (int i = 0; i < 3; i++) {
 				nums[i] = int.Parse(match.Groups[i+1].Value);
 			}
-			if (command.StartsWith("submit")) confirm = true;
-		}
-		match = Regex.Match(command, "submit[^0-9]*");
-		if (match.Success) confirm = true;
-		if (type) {
-			for (int i = 0; i < 3; i++) {
-				int difference = sevenSegmentDigits[nums[i]] ^ this.digits[i].MatchConfiguration;
-				for (int j = 0; j < 7; j++) {
-					if ((difference & 1 << j) != 0) output.Add(this.digits[i][j].Selectable);
+			if (type) {
+				for (int i = 0; i < 3; i++) {
+					int difference = sevenSegmentDigits[nums[i]] ^ this.digits[i].MatchConfiguration;
+					for (int j = 0; j < 7; j++) {
+						if ((difference & 1 << j) != 0) output.Add(this.digits[i][j].Selectable);
+					}
 				}
 			}
 		}
-		if (confirm) output.Add(this.confirmButton);
+		if (submit) output.Add(this.confirmButton);
 		return output;
 	}
 	


### PR DESCRIPTION
This parser should now:
Check if command contains reset, submit or type
if it contains reset, click reset button
if it contains type or submit, find exactly 3 digits to type otherwise don't do anything
if it contains submit and 3 or 0 digits are present, press submit